### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# Introduction
-This repo provides a boilerplate IoTeX Dapp, with examples to use the antenna SDK, connect to the ioPay wallet, show balance, send IOTX and send XRC20 tokens.
+## Introduction
+This repo provides a boilerplate IoTeX Dapp, with examples on how to use the antenna SDK, connect to the ioPay wallet, display wallet balance, send IOTX and XRC20 tokens.
+
+## Live demo
+Try the live demo at https://iotex-dapp-sample.herokuapp.com/
 
 ## Installation
 
@@ -8,14 +11,20 @@ Clone this repository
 git clone https://github.com/iotexproject/iotex-dapp-sample.git
 ```
 
-then run
+enter the project directory
+```
+cd iotex-dapp-sample
+```
+
+run the following
 
 ```bash
+cp .env.tmpl .env
 npm install
 npm run dev
 ```
 
-visit the sample dApp as [localhost:3000](http://localhost:3000)
+visit the sample dApp at [localhost:3000](http://localhost:3000)
 
 ## Deploy on Heroku
 

--- a/README.md
+++ b/README.md
@@ -1,66 +1,27 @@
-# iotex-dapp-sample
+# Introduction
 This repo provides a boilerplate IoTeX Dapp, with examples to use the antenna SDK, connect to the ioPay wallet, show balance, send IOTX and send XRC20 tokens.
 
-## How to Use
+## Installation
 
-Install it and run:
+Clone this repository
+```
+git clone https://github.com/iotexproject/iotex-dapp-sample.git
+```
+
+then run
 
 ```bash
 npm install
 npm run dev
 ```
-### Install Javascript SDK
 
-In your JS project root, use npm install or yarn add.
+visit the sample dApp as [localhost:3000](http://localhost:3000)
 
-```bash
-npm install iotex-antenna
-```
-
-or add the following line to your html.
-
-```bash
-<script src="https://cdn.jsdelivr.net/npm/iotex-antenna@0.29.1/lib/iotex-antenna.browser.min.js"></script>
-```
-
-
-You can simple use the ``` AntennaUtils ``` in our example code:
-
-```bash
-https://github.com/iotexproject/iotex-dapp-sample/blob/master/src/common/utils/antanna.ts
-```
-
-There are two plugin for our different IoPay Wallet:
-
-* For desktop: 
-
-```
-https://github.com/iotexproject/iotex-dapp-sample/blob/master/src/common/utils/ws-plugin.ts
-```
-
-* For mobile:  
-
-```
-https://github.com/iotexproject/iotex-dapp-sample/blob/master/src/common/utils/js-plugin.ts
-```
-
-## Deploy Your Instance on Heroku
+## Deploy on Heroku
 
 <a href="https://heroku.com/deploy?template=https://github.com/iotexproject/iotex-dapp-sample">
   <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
 </a>
 
-
-## Reference
-
-nestjs: https://docs.nestjs.com/
-
-mobx: https://mobx.js.org/README.html
-
-tailwindcss: https://tailwindcss.com/docs/installation/
-
-razzle: https://github.com/jaredpalmer/razzle
-
-ReduxDevTools: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en
-
-wildcard-api: https://github.com/reframejs/wildcard-api
+## Documentation
+Check out https://docs.iotex.io/developer/dapp-starter/introduction.html for more examples and documentation to get started with the IoTeX Sample dApp.


### PR DESCRIPTION
Linked to dApp Starter doc page on docs.iotex.io.

Removed Antenna installation instructions as antenna is provided out of the box (instructions are linked in the dApp docs page anyway).

Also removed how to integrate with IoPay instructions for the same reason above